### PR TITLE
revart & add `vgsmml_compile_from_memory2`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## Version 1.04
+- revart: https://github.com/suzukiplan/vgs-mml-compiler/pull/6
+- added: `vgsmml_compile_from_memory2` as a function without memory destruction
+
 ## Version 1.03
 - ensures duplicate memory of MML string: https://github.com/AmamiyaRinyuki/vgs-bgm-plugins/issues/1
 

--- a/src/vgsmml.h
+++ b/src/vgsmml.h
@@ -27,10 +27,12 @@ struct VgsMmlErrorInfo {
 #ifdef _WIN32
 struct VgsBgmData* __stdcall vgsmml_compile_from_file(const char* path, struct VgsMmlErrorInfo* err);
 struct VgsBgmData* __stdcall vgsmml_compile_from_memory(void* data, size_t size, struct VgsMmlErrorInfo* err);
+struct VgsBgmData* __stdcall vgsmml_compile_from_memory2(const void* data, size_t size, struct VgsMmlErrorInfo* err);
 void __stdcall vgsmml_free_bgm_data(struct VgsBgmData* data);
 #else
 struct VgsBgmData* vgsmml_compile_from_file(const char* path, struct VgsMmlErrorInfo* err);
 struct VgsBgmData* vgsmml_compile_from_memory(void* data, size_t size, struct VgsMmlErrorInfo* err);
+struct VgsBgmData* vgsmml_compile_from_memory2(const void* data, size_t size, struct VgsMmlErrorInfo* err);
 void vgsmml_free_bgm_data(struct VgsBgmData* data);
 #endif
 

--- a/test/test_memchk.c
+++ b/test/test_memchk.c
@@ -7,8 +7,9 @@ int main(int argc, char* argv[])
     struct VgsMmlErrorInfo err;
     char foo[4];
     strcpy(foo, "foo");
-    if (NULL == vgsmml_compile_from_memory(foo, 3, &err) && VGSMML_ERR_SYNTAX_UNKNOWN == err.code && 1 == err.line) {
-        printf("%s (code=%d, line=%d)\n", err.message, err.code, err.line);
+    if (NULL == vgsmml_compile_from_memory(foo, 3, &err) && VGSMML_ERR_INVALID == err.code) {
+        puts(err.message);
+        puts("test succeed");
         return 0;
     }
     puts("test failed");


### PR DESCRIPTION
- revart: https://github.com/suzukiplan/vgs-mml-compiler/pull/6
- added: `vgsmml_compile_from_memory2` as a function without memory destruction
